### PR TITLE
Modernize Julia and QUBO stack compat

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - version: '1.10'
+            os: ubuntu-latest
+            arch: x64
+          - version: '1.10'
+            os: windows-latest
+            arch: x64
           - version: '1'
             os: ubuntu-latest
             arch: x64

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "PySA"
 uuid = "46b73cfa-376a-48ee-8926-0c45ac3f7830"
-authors = ["pedromxavier <mail@pedro.ϵλ>"]
+authors = ["pedromxavier <mail@pedro.ϵλ>", "David E. Bernal Neira <dbernaln@purdue.edu>"]
 version = "0.3.4"
 
 [deps]

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PySA"
 uuid = "46b73cfa-376a-48ee-8926-0c45ac3f7830"
 authors = ["pedromxavier <mail@pedro.ϵλ>"]
-version = "0.3.3"
+version = "0.3.4"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
@@ -13,6 +13,6 @@ QUBOTools = "60eb5b62-0a39-4ddc-84c5-97d2adff9319"
 [compat]
 MathOptInterface = "1"
 PythonCall       = "0.9.23"
-QUBODrivers      = "0.3"
-QUBOTools        = "0.10, 0.11"
-julia            = "1.9"
+QUBODrivers      = "0.3, 0.4"
+QUBOTools        = "0.10, 0.11, 0.12"
+julia            = "1.10"


### PR DESCRIPTION
## Summary

- Widen PySA compat to allow `QUBODrivers v0.4` and `QUBOTools v0.12`.
- Raise the supported Julia floor to `1.10`.
- Bump the package version to `0.3.4` for the follow-up release.
- Add Julia `1.10` CI jobs alongside the existing latest-stable Julia jobs.

## Tests run

- `julia --project=/tmp/pysa-issue4-test.QpQ8oG -e 'using Pkg; Pkg.test()'`
  - Result: passed on Julia `1.10.11`.
  - Resolver selected `QUBODrivers v0.4.0`, `QUBOTools v0.12.0`, and `PseudoBooleanOptimization v0.2.5`.
  - Test summary: 132 passed, 132 total.
- `julia +release --project=/tmp/pysa-issue4-release-test.PRucsn -e 'using Pkg; Pkg.test()'`
  - Result: passed on Julia `1.12.0`.
  - Resolver selected `QUBODrivers v0.4.0`, `QUBOTools v0.12.0`, and `PseudoBooleanOptimization v0.2.5`.
  - Test summary: 133 passed, 133 total.
- `git diff --check`
  - Result: passed.

## Notes

- No lint, formatting, or type-check commands are documented in the repository beyond the Julia package tests used by CI.
- The local checkout contains an ignored `Manifest.toml`, so package tests were run from clean temporary copies without that manifest.

Closes #4
