### PR TITLE
Add QUBODrivers v0.5 compatibility

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,6 +13,6 @@ QUBOTools = "60eb5b62-0a39-4ddc-84c5-97d2adff9319"
 [compat]
 MathOptInterface = "1"
 PythonCall       = "0.9.23"
-QUBODrivers      = "0.3, 0.4"
+QUBODrivers      = "0.3, 0.4, 0.5"
 QUBOTools        = "0.10, 0.11, 0.12"
 julia            = "1.10"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # PySA.jl
 
 [![DOI](https://zenodo.org/badge/621844685.svg)](https://zenodo.org/badge/latestdoi/621844685)
-[![QUBODRIVERS](https://img.shields.io/badge/Powered%20by-QUBODrivers.jl-%20%234063d8)](https://github.com/psrenergy/QUBODrivers.jl)
+[![QUBODRIVERS](https://img.shields.io/badge/Powered%20by-QUBODrivers.jl-%20%234063d8)](https://github.com/JuliaQUBO/QUBODrivers.jl)
 
 [PySA](https://github.com/nasa/pysa) Simulated Annealing Interface for JuMP
 

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,0 +1,3 @@
+[deps]
+TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,17 @@
 import PySA
 import PySA: MOI, QUBODrivers
+import TOML
+using Test
+
+@testset "Package metadata" begin
+    project = TOML.parsefile(joinpath(pkgdir(PySA), "Project.toml"))
+    qubodrivers_compat = split(project["compat"]["QUBODrivers"], r",\s*")
+    readme = read(joinpath(pkgdir(PySA), "README.md"), String)
+
+    @test "0.5" in qubodrivers_compat
+    @test occursin("https://github.com/JuliaQUBO/QUBODrivers.jl", readme)
+    @test !occursin("https://github.com/psrenergy/QUBODrivers.jl", readme)
+end
 
 QUBODrivers.test(PySA.Optimizer; examples=true) do model
     MOI.set(model, MOI.Silent(), true)


### PR DESCRIPTION
## Summary

- Allow PySA to resolve with `QUBODrivers v0.5` by extending the package compat entry.
- Update the README QUBODrivers badge link to the canonical `JuliaQUBO/QUBODrivers.jl` repository.
- Add metadata regression tests for the compat entry and README link.

## Tests run

- `git diff --check` - passed.
- `julia +release -e 'using Pkg; Pkg.activate(temp=true); Pkg.develop(PackageSpec(path=pwd())); Pkg.add(PackageSpec(name="QUBODrivers", version="0.5.0")); Pkg.status(); include(joinpath(pwd(), "test", "runtests.jl"))'` - passed; metadata tests 3/3, QUBODrivers suite 128/128.
- `julia +release -e 'using Pkg; Pkg.activate("."); Pkg.test()'` - passed; metadata tests 3/3, QUBODrivers suite 134/134.
- `julia --project=. -e 'using Pkg; Pkg.activate(temp=true); Pkg.develop(PackageSpec(path=pwd())); Pkg.add(PackageSpec(name="QUBODrivers", version="0.5.0")); Pkg.test("PySA")'` - passed on Julia 1.10.11; metadata tests 3/3, QUBODrivers suite 132/132.

## Notes

- No separate lint, formatting, or type-check commands are documented in this repository.
- Windows CI was not run locally.

Closes #6
Closes #7
