### PR TITLE
Release v0.3.5

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PySA"
 uuid = "46b73cfa-376a-48ee-8926-0c45ac3f7830"
 authors = ["pedromxavier <mail@pedro.ϵλ>", "David E. Bernal Neira <dbernaln@purdue.edu>"]
-version = "0.3.4"
+version = "0.3.5"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"


### PR DESCRIPTION
## Summary

- Bump PySA from `0.3.4` to `0.3.5` for the QUBODrivers v0.5 compatibility release.

## Tests run

- `git diff --check` - passed.
- `julia --project=. -e 'using Pkg; Pkg.activate(temp=true); Pkg.develop(PackageSpec(path=pwd())); Pkg.add(PackageSpec(name="QUBODrivers", version="0.5.0")); Pkg.test("PySA")'` - passed with `PySA v0.3.5` and `QUBODrivers v0.5.0`; metadata tests 3/3, QUBODrivers suite 131/131.
- `julia +release -e 'using Pkg; Pkg.activate("."); Pkg.test()'` - passed with `PySA v0.3.5` and `QUBODrivers v0.5.0`; metadata tests 3/3, QUBODrivers suite 131/131.

## Notes

- No separate lint, formatting, or type-check commands are documented in this repository.
- After this PR lands, register `v0.3.5` in General so users can resolve PySA with `QUBODrivers v0.5`.
