### PR TITLE
Add Dependabot maintenance config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  - package-ecosystem: "julia"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      root-julia-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary

- Adds `.github/dependabot.yml` for dependency maintenance with GitHub Dependabot rather than CompatHelper.
- Enables weekly grouped Julia dependency updates for the root package environment.
- Enables monthly grouped GitHub Actions workflow updates.
- Leaves `test/Project.toml` out of Dependabot because it contains only stdlibs and does not maintain its own `[compat]` bounds.

## Notes

- This repository does not currently have a docs workflow or docs environment, so the Dependabot-only `--skip-deploy` docs path from the ecosystem rollout is not needed here.
- No PAT or custom secret is required for this configuration: the public Julia General registry updates and GitHub Actions updates can use the default Dependabot/GitHub token behavior.
- If this repository later needs private/custom registries or cross-repository workflow triggering from Dependabot PRs, token requirements should be revisited.

## Checks

- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/dependabot.yml")'`

Full Julia tests were not run locally because this is a repository-maintenance config change and package code was not modified.

Closes #10
