### PR TITLE
Fix CI push trigger for main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     types: [opened, synchronize, reopened]
 jobs:


### PR DESCRIPTION
## Summary

- Updates the CI workflow push branch filter from `master` to `main`.

## Why

The repository default branch is `main`, but the CI workflow was still configured to run push builds only for `master`. Pull request checks ran, but merges and direct pushes to `main` did not trigger the CI workflow.

## Checks

- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml")'`
