### PR TITLE
Add CI badge and coverage artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,10 @@ jobs:
           arch: ${{ matrix.arch }}
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
-      # - uses: julia-actions/julia-processcoverage@v1
-      # - uses: codecov/codecov-action@v2
-      #   with:
-      #     file: lcov.info
+      - uses: julia-actions/julia-processcoverage@v1
+        if: matrix.version == '1' && matrix.os == 'ubuntu-latest'
+      - uses: actions/upload-artifact@v4
+        if: matrix.version == '1' && matrix.os == 'ubuntu-latest'
+        with:
+          name: coverage-lcov
+          path: lcov.info

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
         if: matrix.version == '1' && matrix.os == 'ubuntu-latest'
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v5
         if: matrix.version == '1' && matrix.os == 'ubuntu-latest'
         with:
           name: coverage-lcov

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # PySA.jl
 
+[![CI](https://github.com/JuliaQUBO/PySA.jl/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/JuliaQUBO/PySA.jl/actions/workflows/ci.yml)
 [![DOI](https://zenodo.org/badge/621844685.svg)](https://zenodo.org/badge/latestdoi/621844685)
 [![QUBODRIVERS](https://img.shields.io/badge/Powered%20by-QUBODrivers.jl-%20%234063d8)](https://github.com/JuliaQUBO/QUBODrivers.jl)
 


### PR DESCRIPTION
## Summary

- Adds a CI status badge to the README.
- Re-enables Julia coverage processing on the `ubuntu-latest` / Julia `1` CI job.
- Uploads the generated `lcov.info` as a `coverage-lcov` workflow artifact.

## Notes

- This uses a GitHub Actions artifact instead of an external coverage service, so no Codecov token or repository secret is required.
- The docs-site item from issue #14 is intentionally left for a separate follow-up because this repository does not yet have docs content or a docs deployment workflow.

## Checks

- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml")'`
- `actionlint .github/workflows/ci.yml`
- `julia --project=. -e 'using Pkg; Pkg.test()'`

Refs #14
