### PR TITLE
Pin NASA PySA dependency to v0.1.0

### DIFF
--- a/CondaPkg.toml
+++ b/CondaPkg.toml
@@ -5,4 +5,4 @@ python = ">=3.8,<=3.11"
 
 [pip.deps]
 numpy = ">=1.20.0"
-pysa  = "@ git+https://github.com/nasa/pysa"
+pysa  = "@ git+https://github.com/nasa/pysa@v0.1.0"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,12 +9,22 @@ using Test
     qubodrivers_compat = split(project["compat"]["QUBODrivers"], r",\s*")
     readme = read(joinpath(pkgdir(PySA), "README.md"), String)
     source = read(joinpath(pkgdir(PySA), "src", "PySA.jl"), String)
+    pysa_pin = match(r"^@ git\+https://github\.com/nasa/pysa@v(\d+\.\d+\.\d+)$", condapkg["pip"]["deps"]["pysa"])
+    pysa_version = match(r"(?m)^\s*version\s*=\s*v\"(\d+\.\d+\.\d+)\"\s*(?:#.*)?$", source)
 
     @test "0.5" in qubodrivers_compat
     @test occursin("https://github.com/JuliaQUBO/QUBODrivers.jl", readme)
     @test !occursin("https://github.com/psrenergy/QUBODrivers.jl", readme)
-    @test condapkg["pip"]["deps"]["pysa"] == "@ git+https://github.com/nasa/pysa@v0.1.0"
-    @test occursin(r"version\s*=\s*v\"0\.1\.0\"", source)
+    @test pysa_pin !== nothing
+    @test pysa_version !== nothing
+
+    if pysa_pin !== nothing
+        @test pysa_pin.captures[1] == "0.1.0"
+    end
+
+    if pysa_pin !== nothing && pysa_version !== nothing
+        @test pysa_version.captures[1] == pysa_pin.captures[1]
+    end
 end
 
 QUBODrivers.test(PySA.Optimizer; examples=true) do model

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,12 +5,16 @@ using Test
 
 @testset "Package metadata" begin
     project = TOML.parsefile(joinpath(pkgdir(PySA), "Project.toml"))
+    condapkg = TOML.parsefile(joinpath(pkgdir(PySA), "CondaPkg.toml"))
     qubodrivers_compat = split(project["compat"]["QUBODrivers"], r",\s*")
     readme = read(joinpath(pkgdir(PySA), "README.md"), String)
+    source = read(joinpath(pkgdir(PySA), "src", "PySA.jl"), String)
 
     @test "0.5" in qubodrivers_compat
     @test occursin("https://github.com/JuliaQUBO/QUBODrivers.jl", readme)
     @test !occursin("https://github.com/psrenergy/QUBODrivers.jl", readme)
+    @test condapkg["pip"]["deps"]["pysa"] == "@ git+https://github.com/nasa/pysa@v0.1.0"
+    @test occursin(r"version\s*=\s*v\"0\.1\.0\"", source)
 end
 
 QUBODrivers.test(PySA.Optimizer; examples=true) do model


### PR DESCRIPTION
## Summary

- Pin the NASA PySA pip dependency in `CondaPkg.toml` to the upstream `v0.1.0` tag.
- Add metadata tests that verify the CondaPkg pin and the wrapper's declared PySA solver version stay aligned at `0.1.0`.

## Tests

- `julia --project=. -e 'import Pkg; Pkg.test()'`

Closes #18
