### PR TITLE
Add README JuMP smoke test

### DIFF
--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,3 +1,4 @@
 [deps]
+JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
 TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 import PySA
 import PySA: MOI, QUBODrivers
+import JuMP
 import TOML
 using Test
 
@@ -25,6 +26,35 @@ using Test
     if pysa_pin !== nothing && pysa_version !== nothing
         @test pysa_version.captures[1] == pysa_pin.captures[1]
     end
+end
+
+@testset "README JuMP workflow" begin
+    model = JuMP.Model(PySA.Optimizer)
+    JuMP.set_attribute(model, MOI.Silent(), true)
+    JuMP.set_optimizer_attribute(model, PySA.NumberOfReads(), 4)
+    JuMP.set_optimizer_attribute(model, PySA.NumberOfSweeps(), 8)
+    JuMP.set_optimizer_attribute(model, PySA.NumberOfReplicas(), 2)
+    JuMP.set_optimizer_attribute(model, PySA.MinimumTemperature(), 0.5)
+    JuMP.set_optimizer_attribute(model, PySA.MaximumTemperature(), 2.5)
+
+    n = 3
+    Q = [
+        -1  2  2
+         2 -1  2
+         2  2 -1
+    ]
+
+    JuMP.@variable(model, x[1:n], Bin)
+    JuMP.@objective(model, Min, x' * Q * x)
+
+    JuMP.optimize!(model)
+
+    @test JuMP.result_count(model) >= 1
+    @test isfinite(JuMP.objective_value(model; result = 1))
+
+    x_result = JuMP.value.(x; result = 1)
+    @test length(x_result) == n
+    @test all(isapprox(v, 0; atol = 1e-6) || isapprox(v, 1; atol = 1e-6) for v in x_result)
 end
 
 QUBODrivers.test(PySA.Optimizer; examples=true) do model

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -31,11 +31,11 @@ end
 @testset "README JuMP workflow" begin
     model = JuMP.Model(PySA.Optimizer)
     JuMP.set_attribute(model, MOI.Silent(), true)
-    JuMP.set_optimizer_attribute(model, PySA.NumberOfReads(), 4)
-    JuMP.set_optimizer_attribute(model, PySA.NumberOfSweeps(), 8)
-    JuMP.set_optimizer_attribute(model, PySA.NumberOfReplicas(), 2)
-    JuMP.set_optimizer_attribute(model, PySA.MinimumTemperature(), 0.5)
-    JuMP.set_optimizer_attribute(model, PySA.MaximumTemperature(), 2.5)
+    JuMP.set_attribute(model, PySA.NumberOfReads(), 4)
+    JuMP.set_attribute(model, PySA.NumberOfSweeps(), 8)
+    JuMP.set_attribute(model, PySA.NumberOfReplicas(), 2)
+    JuMP.set_attribute(model, PySA.MinimumTemperature(), 0.5)
+    JuMP.set_attribute(model, PySA.MaximumTemperature(), 2.5)
 
     n = 3
     Q = [
@@ -50,7 +50,9 @@ end
     JuMP.optimize!(model)
 
     @test JuMP.result_count(model) >= 1
-    @test isfinite(JuMP.objective_value(model; result = 1))
+    objective = JuMP.objective_value(model; result = 1)
+    @test isfinite(objective)
+    @test objective <= 0
 
     x_result = JuMP.value.(x; result = 1)
     @test length(x_result) == n


### PR DESCRIPTION
Summary:
- Add an explicit README-style JuMP smoke test for `PySA.Optimizer`.
- Configure `MOI.Silent()` plus reads, sweeps, replicas, and temperature bounds in the smoke test.
- Add `JuMP` as a direct test dependency so the README workflow can be exercised by the package tests.

Tests:
- `julia --project=. -e 'import Pkg; Pkg.test()'` passed.

Closes #19
