### PR TITLE
Add Julia CI cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
+      - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,12 +31,12 @@ jobs:
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: julia-actions/cache@v3.1.0
+      - uses: julia-actions/cache@v3
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
         if: matrix.version == '1' && matrix.os == 'ubuntu-latest'
-      - uses: actions/upload-artifact@v7.0.1
+      - uses: actions/upload-artifact@v7
         if: matrix.version == '1' && matrix.os == 'ubuntu-latest'
         with:
           name: coverage-lcov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
         if: matrix.version == '1' && matrix.os == 'ubuntu-latest'
-      - uses: actions/upload-artifact@v5
+      - uses: actions/upload-artifact@v7.0.1
         if: matrix.version == '1' && matrix.os == 'ubuntu-latest'
         with:
           name: coverage-lcov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: julia-actions/cache@v2
+      - uses: julia-actions/cache@v3.1.0
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1


### PR DESCRIPTION
## Summary

- Adds `julia-actions/cache@v3` after Julia setup and before `julia-buildpkg`.
- Updates `actions/upload-artifact` from `v5` to `v7`, which removes the Node 20 deprecation annotation seen while benchmarking.
- Keeps package code unchanged; this is limited to CI workflow behavior.

## Benchmark

No-cache medians from #23:

| Job | Median total | Median build | Median test |
| --- | ---: | ---: | ---: |
| Julia 1.10 Ubuntu | 2m42s | 16s | 2m16s |
| Julia 1 Ubuntu | 4m16s | 12s | 3m26s |
| Julia 1.10 Windows | 5m08s | 40s | 4m05s |
| Julia 1 Windows | 6m37s | 30s | 5m40s |

Cold/warm cache benchmark with `julia-actions/cache@v3.1.0` on run 27117362896:

| Job | Cold total | Warm total | Delta | Cold test | Warm test | Warm cache restore | Warm cache save |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Julia 1.10 Ubuntu | 2m56s | 1m48s | -68s (-39%) | 2m16s | 1m06s | 10s | 9s |
| Julia 1 Ubuntu | 4m33s | 1m53s | -160s (-59%) | 3m37s | 1m14s | 7s | 7s |
| Julia 1.10 Windows | 5m23s | 3m42s | -101s (-31%) | 4m05s | 2m17s | 32s | 18s |
| Julia 1 Windows | 7m51s | 4m11s | -220s (-47%) | 6m22s | 2m22s | 43s | 27s |

The cache adds save overhead on cold runs, but warm runs are materially faster. The direct v3 benchmark improved the matrix critical path from 7m51s to 4m11s (-220s, -47%). At review time, `julia-actions/cache@v3` resolves to the same tag SHA as `v3.1.0`.

Final branch validation after switching to major action tags used run 27119881459:

| Job | Total | Build | Test | Cache restore | Cache save |
| --- | ---: | ---: | ---: | ---: | ---: |
| Julia 1.10 Ubuntu | 1m48s | 11s | 1m07s | 9s | 8s |
| Julia 1 Ubuntu | 1m54s | 8s | 1m13s | 8s | 8s |
| Julia 1.10 Windows | 3m30s | 16s | 2m09s | 32s | 15s |
| Julia 1 Windows | 3m56s | 9s | 1m59s | 43s | 28s |

The latest final-workflow attempt's matrix critical path was 3m56s, still materially below the 6m37s no-cache baseline critical path from #23. The final workflow passed with `julia-actions/cache@v3` and `actions/upload-artifact@v7`.

## Validation

- `git diff --check`
- `actionlint .github/workflows/ci.yml`
- `julia --project=. -e 'using Pkg; Pkg.test()'`
- CI run 27117362896: pass after cold and warm attempts
- CI run 27119881459: pass after switching new actions to major tags

Closes #23
