### PR TITLE
[codex] Add QUBODrivers 0.6.1 conformance

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,6 +13,6 @@ QUBOTools = "60eb5b62-0a39-4ddc-84c5-97d2adff9319"
 [compat]
 MathOptInterface = "1"
 PythonCall       = "0.9.23"
-QUBODrivers      = "0.3, 0.4, 0.5, 0.6"
-QUBOTools        = "0.10, 0.11, 0.12, 0.13"
+QUBODrivers      = "0.6.1"
+QUBOTools        = "0.13"
 julia            = "1.10"

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ model = Model(PySA.Optimizer)
 set_silent(model)
 set_attribute(model, PySA.NumberOfReads(), 20)
 set_attribute(model, PySA.NumberOfSweeps(), 64)
+set_attribute(model, PySA.RandomSeed(), 1234)
 
 n = 3
 Q = [ -1  2  2
@@ -42,23 +43,28 @@ end
 
 ## Solver options
 
-PySA.jl exposes the main PySA simulated annealing options as JuMP optimizer attributes:
+PySA.jl exposes the main PySA simulated annealing options as JuMP optimizer attributes.
+Each option can also be set with `MOI.RawOptimizerAttribute` using the raw key.
+Legacy `n_*` raw keys remain supported for compatibility.
 
-| Attribute | PySA option | Default |
-| --- | --- | --- |
-| `PySA.NumberOfSweeps()` | `n_sweeps` | `32` |
-| `PySA.NumberOfReplicas()` | `n_replicas` | `3` |
-| `PySA.NumberOfReads()` | `n_reads` | `10` |
-| `PySA.MinimumTemperature()` | `min_temp` | `1.0` |
-| `PySA.MaximumTemperature()` | `max_temp` | `3.5` |
-| `PySA.UpdateStrategy()` | `update_strategy` | `"sequential"` |
-| `PySA.InitializeStrategy()` | `initialize_strategy` | `"ones"` |
-| `PySA.RecomputeEnergy()` | `recompute_energy` | `false` |
-| `PySA.SortOutputTemps()` | `sort_output_temps` | `true` |
-| `PySA.Parallel()` | `parallel` | `true` |
+| Attribute | Raw key | Alias raw key | Default |
+| --- | --- | --- | --- |
+| `PySA.NumberOfSweeps()` | `num_sweeps` | `n_sweeps` | `32` |
+| `PySA.NumberOfReplicas()` | `num_replicas` | `n_replicas` | `3` |
+| `PySA.NumberOfReads()` | `num_reads` | `n_reads` | `10` |
+| `PySA.FinalNumberOfReads()` | `final_num_reads` | - | `num_reads` |
+| `PySA.RandomSeed()` | `seed` | - | `nothing` |
+| `PySA.MinimumTemperature()` | `min_temp` | `minimum_temperature` | `1.0` |
+| `PySA.MaximumTemperature()` | `max_temp` | `maximum_temperature` | `3.5` |
+| `PySA.UpdateStrategy()` | `update_strategy` | - | `"sequential"` |
+| `PySA.InitializeStrategy()` | `initialize_strategy` | - | `"ones"` |
+| `PySA.RecomputeEnergy()` | `recompute_energy` | - | `false` |
+| `PySA.SortOutputTemps()` | `sort_output_temps` | - | `true` |
+| `PySA.Parallel()` | `parallel` | - | `true` |
 
 Use `set_attribute(model, attribute, value)` to override these values before calling `optimize!`.
 Use `set_silent(model)` to disable PySA solver output.
+When `PySA.RandomSeed()` is set, PySA.jl runs the backend with `parallel=false` so NumPy and Numba random streams are reproducible.
 
 **Note**: _The PySA wrapper for Julia is not officially supported by the National Aeronautics and Space Administration. If you are interested in official support for Julia from NASA, let them know!_
 

--- a/src/PySA.jl
+++ b/src/PySA.jl
@@ -10,20 +10,36 @@ import MathOptInterface as MOI
 const np      = PythonCall.pynew()
 const pysa    = PythonCall.pynew()
 const pysa_sa = PythonCall.pynew()
+const seed_numba_rng = PythonCall.pynew()
 
 function __init__()
     PythonCall.pycopy!(np, pyimport("numpy"))
     PythonCall.pycopy!(pysa, pyimport("pysa"))
     PythonCall.pycopy!(pysa_sa, pyimport("pysa.sa"))
+
+    ns = PythonCall.pydict()
+    pyimport("builtins").exec(
+        """
+        import numpy as np
+        import numba
+
+        @numba.njit
+        def seed_numba_rng(seed):
+            np.random.seed(seed)
+        """,
+        ns,
+    )
+    PythonCall.pycopy!(seed_numba_rng, ns["seed_numba_rng"])
 end
 
 QUBODrivers.@setup Optimizer begin
     name       = "PySA"
     version    = v"0.1.0" # pysa version
     attributes = begin
-        NumberOfSweeps["n_sweeps"]::Integer = 32
-        NumberOfReplicas["n_replicas"]::Integer = 3
-        NumberOfReads["n_reads"]::Integer = 10
+        NumberOfSweeps["num_sweeps"]::Integer = 32
+        NumberOfReplicas["num_replicas"]::Integer = 3
+        NumberOfReads["num_reads"]::Integer = 10
+        "seed"::Union{Integer,Nothing} = nothing
         MinimumTemperature["min_temp"]::Float64 = 1.0
         MaximumTemperature["max_temp"]::Float64 = 3.5
         UpdateStrategy["update_strategy"]::String = "sequential"
@@ -33,6 +49,55 @@ QUBODrivers.@setup Optimizer begin
         Parallel["parallel"]::Bool = true
     end
 end
+
+const RandomSeed = QUBODrivers.RandomSeed
+const FinalNumberOfReads = QUBODrivers.FinalNumberOfReads
+
+const _RawLegacyNumberOfSweeps = QUBODrivers.RawSamplerAttribute{Symbol("n_sweeps")}
+const _RawLegacyNumberOfReplicas = QUBODrivers.RawSamplerAttribute{Symbol("n_replicas")}
+const _RawLegacyNumberOfReads = QUBODrivers.RawSamplerAttribute{Symbol("n_reads")}
+const _RawMinimumTemperature = QUBODrivers.RawSamplerAttribute{Symbol("minimum_temperature")}
+const _RawMaximumTemperature = QUBODrivers.RawSamplerAttribute{Symbol("maximum_temperature")}
+
+MOI.get(sampler::Optimizer, ::_RawLegacyNumberOfSweeps) = MOI.get(sampler, NumberOfSweeps())
+MOI.get(sampler::Optimizer, ::_RawLegacyNumberOfReplicas) = MOI.get(sampler, NumberOfReplicas())
+MOI.get(sampler::Optimizer, ::_RawLegacyNumberOfReads) = MOI.get(sampler, NumberOfReads())
+MOI.get(sampler::Optimizer, ::_RawMinimumTemperature) = MOI.get(sampler, MinimumTemperature())
+MOI.get(sampler::Optimizer, ::_RawMaximumTemperature) = MOI.get(sampler, MaximumTemperature())
+
+function MOI.set(sampler::Optimizer, ::_RawLegacyNumberOfSweeps, value)
+    MOI.set(sampler, NumberOfSweeps(), value)
+    return nothing
+end
+
+function MOI.set(sampler::Optimizer, ::_RawLegacyNumberOfReplicas, value)
+    MOI.set(sampler, NumberOfReplicas(), value)
+    return nothing
+end
+
+function MOI.set(sampler::Optimizer, ::_RawLegacyNumberOfReads, value)
+    MOI.set(sampler, NumberOfReads(), value)
+    return nothing
+end
+
+function MOI.set(sampler::Optimizer, ::_RawMinimumTemperature, value)
+    MOI.set(sampler, MinimumTemperature(), value)
+    return nothing
+end
+
+function MOI.set(sampler::Optimizer, ::_RawMaximumTemperature, value)
+    MOI.set(sampler, MaximumTemperature(), value)
+    return nothing
+end
+
+MOI.supports(::Optimizer, ::_RawLegacyNumberOfSweeps) = true
+MOI.supports(::Optimizer, ::_RawLegacyNumberOfReplicas) = true
+MOI.supports(::Optimizer, ::_RawLegacyNumberOfReads) = true
+MOI.supports(::Optimizer, ::_RawMinimumTemperature) = true
+MOI.supports(::Optimizer, ::_RawMaximumTemperature) = true
+
+QUBODrivers.honors_final_reads(::Type{<:Optimizer}) = true
+QUBODrivers.enforces_time_limit(::Type{<:Optimizer}) = false
 
 function _float_type(::Type{T})::String where {T<:AbstractFloat}
     if T === Float16
@@ -44,6 +109,46 @@ function _float_type(::Type{T})::String where {T<:AbstractFloat}
     else
         error("Unknown float type '$T'")
     end
+end
+
+function _check_nonnegative_integer(name::String, value::Integer)
+    value >= 0 || error("Value for '$name' must be a non-negative integer")
+
+    return nothing
+end
+
+function _seed_backend!(::Nothing)
+    return nothing
+end
+
+function _seed_backend!(seed::Integer)
+    np.random.seed(seed)
+    seed_numba_rng(seed)
+
+    return nothing
+end
+
+function _pysa_spin_sample(state, h, J, α, β, ::Type{T}) where {T}
+    ψ = -round.(Int, pyconvert.(T, [var for var in state]))
+    λ = QUBOTools.value(ψ, h, J, α, β)
+
+    return QUBOTools.Sample{T,Int}(ψ, λ)
+end
+
+function _final_samples(result, final_num_reads::Integer, h, J, α, β, ::Type{T}) where {T}
+    best_states = result["best_state"].values
+    backend_num_reads = length(best_states)
+    samples = Vector{QUBOTools.Sample{T,Int}}(undef, backend_num_reads)
+
+    for i = 1:backend_num_reads
+        # NOTE: Python is 0-indexed
+        # NOTE: sign has to be inverted, as mentioned before
+        samples[i] = _pysa_spin_sample(best_states[i-1], h, J, α, β, T)
+    end
+
+    sort!(samples; by = QUBOTools.value)
+
+    return samples[1:final_num_reads]
 end
 
 function QUBODrivers.sample(sampler::Optimizer{T}) where {T}
@@ -60,42 +165,76 @@ function QUBODrivers.sample(sampler::Optimizer{T}) where {T}
         float_type   = _float_type(T),
     )
 
+    num_sweeps = MOI.get(sampler, PySA.NumberOfSweeps())
     num_replicas = MOI.get(sampler, PySA.NumberOfReplicas())
+    num_reads = MOI.get(sampler, PySA.NumberOfReads())
+    final_num_reads = MOI.get(sampler, QUBODrivers.FinalNumberOfReads())
+    seed = MOI.get(sampler, QUBODrivers.RandomSeed())
+    requested_parallel = MOI.get(sampler, PySA.Parallel())
+    backend_parallel = requested_parallel && isnothing(seed)
+    backend_num_reads = max(num_reads, final_num_reads)
 
-    result = @timed solver.metropolis_update(
-        num_sweeps          = MOI.get(sampler, PySA.NumberOfSweeps()),
-        num_reads           = MOI.get(sampler, PySA.NumberOfReads()),
-        num_replicas        = num_replicas,
-        update_strategy     = MOI.get(sampler, PySA.UpdateStrategy()),
-        min_temp            = MOI.get(sampler, PySA.MinimumTemperature()),
-        max_temp            = MOI.get(sampler, PySA.MaximumTemperature()),
-        initialize_strategy = MOI.get(sampler, PySA.InitializeStrategy()),
-        recompute_energy    = MOI.get(sampler, PySA.RecomputeEnergy()),
-        sort_output_temps   = MOI.get(sampler, PySA.SortOutputTemps()),
-        parallel            = MOI.get(sampler, PySA.Parallel()), # True by default
-        verbose             = !MOI.get(sampler, MOI.Silent()),
-    )
+    _check_nonnegative_integer("NumberOfSweeps", num_sweeps)
+    _check_nonnegative_integer("NumberOfReplicas", num_replicas)
+    _check_nonnegative_integer("NumberOfReads", num_reads)
+    _check_nonnegative_integer("FinalNumberOfReads", final_num_reads)
+    num_replicas > 0 || error("Value for 'NumberOfReplicas' must be positive")
 
-    samples = Vector{QUBOTools.Sample{T,Int}}(undef, num_replicas)
-
-    for Ψ in result.value["states"].values
-        for i = 1:num_replicas
-            # NOTE: Python is 0-indexed
-            # NOTE: sign has to be inverted, as mentioned before
-            ψ = -round.(Int, pyconvert.(T, [var for var in Ψ[i-1]]))
-
-            # Compute value instead of retrieving it, to avoid precision errors
-            λ = QUBOTools.value(ψ, h, J, α, β) 
-
-            samples[i] = QUBOTools.Sample{T,Int}(ψ, λ)
+    result = @timed begin
+        if backend_num_reads == 0
+            nothing
+        else
+            _seed_backend!(seed)
+            solver.metropolis_update(
+                num_sweeps          = num_sweeps,
+                num_reads           = backend_num_reads,
+                num_replicas        = num_replicas,
+                update_strategy     = MOI.get(sampler, PySA.UpdateStrategy()),
+                min_temp            = MOI.get(sampler, PySA.MinimumTemperature()),
+                max_temp            = MOI.get(sampler, PySA.MaximumTemperature()),
+                initialize_strategy = MOI.get(sampler, PySA.InitializeStrategy()),
+                recompute_energy    = MOI.get(sampler, PySA.RecomputeEnergy()),
+                sort_output_temps   = MOI.get(sampler, PySA.SortOutputTemps()),
+                parallel            = backend_parallel,
+                verbose             = !MOI.get(sampler, MOI.Silent()),
+            )
         end
     end
 
-    metadata = Dict{String,Any}(
-        "origin" => "PySA",
-        "time"   => Dict{String,Any}(
-            "effective" => result.time
-        ),
+    samples = if backend_num_reads == 0
+        QUBOTools.Sample{T,Int}[]
+    else
+        _final_samples(result.value, final_num_reads, h, J, α, β, T)
+    end
+
+    seeds = if isnothing(seed)
+        Dict{String,Any}()
+    else
+        Dict{String,Any}("numpy" => seed, "numba" => seed)
+    end
+
+    metadata = QUBODrivers._sampler_metadata(
+        origin                = "PySA.jl",
+        algorithm_name        = "simulated_annealing",
+        backend_name          = "pysa",
+        backend_version       = MOI.get(sampler, MOI.SolverVersion()),
+        execution_mode        = backend_parallel ? "parallel" : "sequential",
+        optimizer_iterations  = num_sweeps,
+        optimizer_evaluations = backend_num_reads * num_replicas,
+        number_of_reads       = backend_num_reads,
+        final_number_of_reads = final_num_reads,
+        seeds                 = seeds,
+        status                = "locally_solved",
+        termination_status    = MOI.LOCALLY_SOLVED,
+    )
+    metadata["time"] = Dict{String,Any}("effective" => result.time)
+    metadata["parameters"] = Dict{String,Any}(
+        "num_sweeps"         => num_sweeps,
+        "num_replicas"       => num_replicas,
+        "num_reads"          => num_reads,
+        "final_num_reads"    => final_num_reads,
+        "requested_parallel" => requested_parallel,
+        "parallel"           => backend_parallel,
     )
 
     return QUBOTools.SampleSet{T}(samples, metadata; domain = :spin, sense = :min)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 import PySA
-import PySA: MOI, QUBODrivers
+import PySA: MOI, QUBODrivers, QUBOTools
 import JuMP
 import TOML
 using Test
@@ -13,7 +13,9 @@ using Test
     pysa_pin = match(r"^@ git\+https://github\.com/nasa/pysa@v(\d+\.\d+\.\d+)$", condapkg["pip"]["deps"]["pysa"])
     pysa_version = match(r"(?m)^\s*version\s*=\s*v\"(\d+\.\d+\.\d+)\"\s*(?:#.*)?$", source)
 
-    @test "0.5" in qubodrivers_compat
+    @test project["compat"]["QUBODrivers"] == "0.6.1"
+    @test project["compat"]["QUBOTools"] == "0.13"
+    @test !("0.5" in qubodrivers_compat)
     @test occursin("https://github.com/JuliaQUBO/QUBODrivers.jl", readme)
     @test !occursin("https://github.com/psrenergy/QUBODrivers.jl", readme)
     @test occursin("## Solver options", readme)
@@ -21,6 +23,8 @@ using Test
         "PySA.NumberOfSweeps()",
         "PySA.NumberOfReplicas()",
         "PySA.NumberOfReads()",
+        "PySA.FinalNumberOfReads()",
+        "PySA.RandomSeed()",
         "PySA.MinimumTemperature()",
         "PySA.MaximumTemperature()",
         "PySA.UpdateStrategy()",
@@ -43,10 +47,54 @@ using Test
     end
 end
 
+@testset "Solver attributes" begin
+    sampler = PySA.Optimizer()
+
+    @test MOI.supports(sampler, PySA.RandomSeed())
+    @test MOI.supports(sampler, PySA.FinalNumberOfReads())
+    @test QUBODrivers.supports_seed(PySA.Optimizer)
+    @test QUBODrivers.honors_final_reads(PySA.Optimizer)
+    @test !QUBODrivers.enforces_time_limit(PySA.Optimizer)
+
+    MOI.set(sampler, PySA.RandomSeed(), 123)
+    @test MOI.get(sampler, PySA.RandomSeed()) == 123
+    @test MOI.get(sampler, MOI.RawOptimizerAttribute("seed")) == 123
+
+    MOI.set(sampler, PySA.FinalNumberOfReads(), 4)
+    @test MOI.get(sampler, PySA.FinalNumberOfReads()) == 4
+    @test MOI.get(sampler, MOI.RawOptimizerAttribute("final_num_reads")) == 4
+
+    MOI.set(sampler, MOI.RawOptimizerAttribute("n_reads"), 3)
+    @test MOI.get(sampler, PySA.NumberOfReads()) == 3
+    @test MOI.get(sampler, MOI.RawOptimizerAttribute("num_reads")) == 3
+
+    MOI.set(sampler, MOI.RawOptimizerAttribute("num_reads"), 5)
+    @test MOI.get(sampler, PySA.NumberOfReads()) == 5
+    @test MOI.get(sampler, MOI.RawOptimizerAttribute("n_reads")) == 5
+
+    MOI.set(sampler, MOI.RawOptimizerAttribute("n_sweeps"), 7)
+    @test MOI.get(sampler, PySA.NumberOfSweeps()) == 7
+    @test MOI.get(sampler, MOI.RawOptimizerAttribute("num_sweeps")) == 7
+
+    MOI.set(sampler, MOI.RawOptimizerAttribute("n_replicas"), 2)
+    @test MOI.get(sampler, PySA.NumberOfReplicas()) == 2
+    @test MOI.get(sampler, MOI.RawOptimizerAttribute("num_replicas")) == 2
+
+    MOI.set(sampler, MOI.RawOptimizerAttribute("minimum_temperature"), 0.25)
+    @test MOI.get(sampler, PySA.MinimumTemperature()) == 0.25
+    @test MOI.get(sampler, MOI.RawOptimizerAttribute("min_temp")) == 0.25
+
+    MOI.set(sampler, MOI.RawOptimizerAttribute("maximum_temperature"), 4.0)
+    @test MOI.get(sampler, PySA.MaximumTemperature()) == 4.0
+    @test MOI.get(sampler, MOI.RawOptimizerAttribute("max_temp")) == 4.0
+end
+
 @testset "README JuMP workflow" begin
     model = JuMP.Model(PySA.Optimizer)
     JuMP.set_attribute(model, MOI.Silent(), true)
+    JuMP.set_attribute(model, PySA.RandomSeed(), 123)
     JuMP.set_attribute(model, PySA.NumberOfReads(), 4)
+    JuMP.set_attribute(model, PySA.FinalNumberOfReads(), 4)
     JuMP.set_attribute(model, PySA.NumberOfSweeps(), 8)
     JuMP.set_attribute(model, PySA.NumberOfReplicas(), 2)
     JuMP.set_attribute(model, PySA.MinimumTemperature(), 0.5)
@@ -72,8 +120,16 @@ end
     x_result = JuMP.value.(x; result = 1)
     @test length(x_result) == n
     @test all(isapprox(v, 0; atol = 1e-6) || isapprox(v, 1; atol = 1e-6) for v in x_result)
+
+    raw = MOI.get(JuMP.backend(model), MOI.RawSolver())
+    metadata = QUBOTools.metadata(QUBOTools.solution(raw))
+    @test isempty(QUBODrivers.validate_metadata(metadata))
+    @test metadata["reads"]["final_number_of_reads"] == 4
+    @test metadata["seeds"]["sampler"] == 123
 end
 
-QUBODrivers.test(PySA.Optimizer; examples=true) do model
+QUBODrivers.test(PySA.Optimizer; examples=true, benchmark_conformance=true) do model
     MOI.set(model, MOI.Silent(), true)
+    MOI.set(model, PySA.NumberOfSweeps(), 8)
+    MOI.set(model, PySA.NumberOfReplicas(), 2)
 end


### PR DESCRIPTION
Refs #26.

## Summary

- Tighten compat to `QUBODrivers = "0.6.1"` and `QUBOTools = "0.13"`.
- Add the standard `PySA.RandomSeed()` and `PySA.FinalNumberOfReads()` aliases, standard `num_*` raw keys, and compatibility raw aliases for the legacy `n_*` keys.
- Seed both NumPy and Numba RNGs for reproducible PySA runs; seeded solves run the backend with `parallel=false` because PySA's parallel Numba kernel is not deterministic.
- Emit QUBODrivers benchmark metadata for backend, reads, seeds, status, and effective time, and declare seed, final-read, and time-limit traits.
- Update tests and README coverage for the new compat, aliases, metadata, and benchmark conformance suite.

## Tests

- `julia --project=. -e 'using Pkg; Pkg.test()'`
  - Passed with `QUBODrivers v0.6.1`, `QUBOTools v0.13.1`, and `PythonCall v0.9.35`.
  - Result summaries: `Package metadata` 22/22, `Solver attributes` 21/21, `README JuMP workflow` 8/8, `QUBODrivers` 139/139.
  - Benchmark Conformance: 13/13.
- `julia --project=/tmp/pysa-issue26-qubo-resolve -e 'using Pkg; Pkg.activate("/tmp/pysa-issue26-qubo-resolve"; shared=false); Pkg.add(Pkg.PackageSpec(name="QUBO", version="0.6")); Pkg.develop(path=pwd()); Pkg.status()'`
  - Passed; resolved `QUBO v0.6.0` with this PySA branch, `QUBODrivers v0.6.1`, and `QUBOTools v0.13.1`.

## Branch Hygiene

- Base branch: `main`.
- Source branch point: `origin/main` at `fccd0dd`.
- Stacked status: not stacked.
- Prerequisite PRs: none.

## Notes

- This PR does not tag or register a release. Keep issue #26 open for the release and registration checkpoint after merge.
