### PR TITLE
ci: collect coverage on one matrix job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,15 +16,19 @@ jobs:
           - version: '1.10'
             os: ubuntu-latest
             arch: x64
+            coverage: false
           - version: '1.10'
             os: windows-latest
             arch: x64
+            coverage: false
           - version: '1'
             os: ubuntu-latest
             arch: x64
+            coverage: true
           - version: '1'
             os: windows-latest
             arch: x64
+            coverage: false
     steps:
       - uses: actions/checkout@v7
       - uses: julia-actions/setup-julia@v3
@@ -34,10 +38,12 @@ jobs:
       - uses: julia-actions/cache@v3
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
+        with:
+          coverage: ${{ matrix.coverage }}
       - uses: julia-actions/julia-processcoverage@v1
-        if: matrix.version == '1' && matrix.os == 'ubuntu-latest'
+        if: matrix.coverage
       - uses: actions/upload-artifact@v7
-        if: matrix.version == '1' && matrix.os == 'ubuntu-latest'
+        if: matrix.coverage
         with:
           name: coverage-lcov
           path: lcov.info


### PR DESCRIPTION
## Summary

- mark Julia current/Ubuntu as the single coverage producer
- disable coverage instrumentation on the other three matrix jobs while retaining their full tests
- use the same matrix field for test instrumentation, coverage processing, and artifact upload

## Validation

- `actionlint`
- `git diff --check`
- full Julia 1.10/current × Ubuntu/Windows CI matrix (post-push)

## Measurement

Issue #32 recorded 19.3 aggregate runner-minutes and three jobs whose coverage output was discarded.

- attempt 1: 19.6 aggregate runner-minutes; longest job 6m27s
- warm rerun: 12.4 aggregate runner-minutes; longest job 4m59s
- Julia current/Ubuntu logged `coverage=true` and processed coverage; a sampled noncanonical job logged `coverage=false`, and all three noncanonical processing/upload steps were skipped

The warm rerun used 7.2 fewer aggregate runner-minutes than attempt 1 while retaining all four full test jobs.

## Branch Hygiene

- Base: `main` at `b2c5f5d21590d7ec48a6e2f5c45afd2697860d91`
- Not stacked; open PR #31 changes `test/runtests.jl`, not the workflow changed here.

Closes #32
